### PR TITLE
BAR-362: Undersøke om Jackson fungerer bedre med Kotlin data class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,29 @@
             <version>${spock.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- BAR-362 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/kotlin/no/ssb/barn/converter/BarnvernConverterJackson.kt
+++ b/src/main/kotlin/no/ssb/barn/converter/BarnvernConverterJackson.kt
@@ -1,0 +1,39 @@
+package no.ssb.barn.converter
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import no.ssb.barn.xsd.jackson.BarnevernTypeJackson
+
+object BarnvernConverterJackson {
+
+    private val kotlinModule: KotlinModule = KotlinModule.Builder()
+        .configure(KotlinFeature.StrictNullChecks, false)
+        // needed, else it will break for null https://github.com/FasterXML/jackson-module-kotlin/issues/130#issuecomment-546625625
+        .configure(KotlinFeature.NullIsSameAsDefault, true)
+        .build()
+
+    private val xmlMapper =
+        XmlMapper(JacksonXmlModule())
+            .registerModule(kotlinModule)
+            .registerModule(JavaTimeModule())
+            .registerModule(JaxbAnnotationModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // to parse the dates as LocalDate, else parsing error
+            .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+
+    @JvmStatic
+    fun unmarshallXml(xml: String): BarnevernTypeJackson {
+        return xmlMapper.readValue(xml, BarnevernTypeJackson::class.java)
+    }
+
+    @JvmStatic
+    fun marshallInstance(barnevernType: BarnevernTypeJackson): String {
+        return xmlMapper.writeValueAsString(barnevernType)
+    }
+}

--- a/src/main/kotlin/no/ssb/barn/xsd/jackson/BarnevernTypeJackson.kt
+++ b/src/main/kotlin/no/ssb/barn/xsd/jackson/BarnevernTypeJackson.kt
@@ -1,0 +1,35 @@
+package no.ssb.barn.xsd.jackson
+
+import no.ssb.barn.xsd.AvgiverType
+import no.ssb.barn.xsd.FagsystemType
+import no.ssb.barn.xsd.SakType
+import java.time.ZonedDateTime
+import java.util.*
+import javax.xml.bind.annotation.*
+
+@XmlRootElement(name = "Barnevern")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(
+    name = "BarnevernType",
+    propOrder = ["id", "datoUttrekk", "forrigeId", "fagsystem", "avgiver", "sak"]
+)
+data class BarnevernTypeJackson(
+    @field:XmlAttribute(name = "Id", required = true)
+    val id: UUID,
+
+    @field:XmlAttribute(name = "ForrigeId")
+    val forrigeId: String?,
+
+    @field:XmlAttribute(name = "DatoUttrekk", required = true)
+    @field:XmlSchemaType(name = "dateTime")
+    val datoUttrekk: ZonedDateTime,
+
+    @field:XmlElement(name = "Fagsystem", required = true)
+    val fagsystem: FagsystemType,
+
+    @field:XmlElement(name = "Avgiver", required = true)
+    val avgiver: AvgiverType,
+
+    @field:XmlElement(name = "Sak", type = SakType::class, required = true)
+    val sak: SakTypeJackson
+)

--- a/src/main/kotlin/no/ssb/barn/xsd/jackson/MeldingTypeJackson.kt
+++ b/src/main/kotlin/no/ssb/barn/xsd/jackson/MeldingTypeJackson.kt
@@ -1,0 +1,44 @@
+package no.ssb.barn.xsd.jackson
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import no.ssb.barn.xsd.MelderType
+import no.ssb.barn.xsd.MeldingKonklusjonType
+import no.ssb.barn.xsd.SaksinnholdType
+import java.time.LocalDate
+import java.util.*
+import javax.xml.bind.annotation.*
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(
+    name = "MeldingType",
+    propOrder = ["id", "migrertId", "startDato", "melder", "saksinnhold", "konklusjon"]
+)
+data class MeldingTypeJackson(
+    @field:XmlAttribute(name = "Id", required = true)
+    var id: UUID? = null,
+
+    @field:XmlAttribute(name = "MigrertId")
+    var migrertId: String? = null,
+
+    @field:XmlAttribute(name = "StartDato", required = true)
+    @field:XmlSchemaType(name = "date")
+    var startDato: LocalDate? = null,
+
+    @field:XmlElement(name = "Konklusjon")
+    var konklusjon: MeldingKonklusjonType? = null
+) {
+    @JacksonXmlProperty(localName = "Melder")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    var melder: List<MelderType> = mutableListOf()
+        set(value) {
+            field = melder + value
+        }
+
+    @JacksonXmlProperty(localName = "Saksinnhold")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    var saksinnhold: List<SaksinnholdType> = mutableListOf()
+        set(value) {
+            field = saksinnhold + value
+        }
+}

--- a/src/main/kotlin/no/ssb/barn/xsd/jackson/SakTypeJackson.kt
+++ b/src/main/kotlin/no/ssb/barn/xsd/jackson/SakTypeJackson.kt
@@ -1,0 +1,58 @@
+package no.ssb.barn.xsd.jackson
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import no.ssb.barn.xsd.MeldingType
+import java.time.LocalDate
+import java.util.*
+import javax.xml.bind.annotation.*
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(
+    name = "SakType",
+    propOrder = ["id", "migrertId", "startDato", "sluttDato",
+        "journalnummer", "fodselsnummer", "duFnummer", "fodseldato", "kjonn",
+        "avsluttet", "melding", "undersokelse", "plan", "tiltak", "vedtak", "ettervern", "oversendelseBarneverntjeneste",
+        "flytting", "relasjon", "slettet"]
+)
+data class SakTypeJackson(
+    @field:XmlAttribute(name = "Id", required = true)
+    val id: UUID,
+
+    @field:XmlAttribute(name = "MigrertId")
+    val migrertId: String?,
+
+    @field:XmlAttribute(name = "StartDato", required = true)
+    @field:XmlSchemaType(name = "date")
+    val startDato: LocalDate,
+
+    @field:XmlAttribute(name = "SluttDato")
+    @field:XmlSchemaType(name = "date")
+    val sluttDato: LocalDate?,
+
+    @field:XmlAttribute(name = "Journalnummer", required = true)
+    val journalnummer: String,
+
+    @field:XmlAttribute(name = "Fodselsnummer")
+    val fodselsnummer: String?,
+
+    @field:XmlAttribute(name = "DUFnummer")
+    val duFnummer: String?,
+
+    @field:XmlAttribute(name = "Fodseldato")
+    @field:XmlSchemaType(name = "date")
+    val fodseldato: LocalDate?,
+
+    @field:XmlAttribute(name = "Kjonn")
+    val kjonn: String?,
+
+    @field:XmlAttribute(name = "Avsluttet")
+    val avsluttet: Boolean?
+) {
+    @JacksonXmlProperty(localName = "Melding")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    var meldinger: List<MeldingType> = mutableListOf()
+        set(value) {
+            field = meldinger + value
+        }
+}

--- a/src/main/kotlin/no/ssb/barn/xsd/jackson/SakTypeJackson.kt
+++ b/src/main/kotlin/no/ssb/barn/xsd/jackson/SakTypeJackson.kt
@@ -2,7 +2,6 @@ package no.ssb.barn.xsd.jackson
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import no.ssb.barn.xsd.MeldingType
 import java.time.LocalDate
 import java.util.*
 import javax.xml.bind.annotation.*
@@ -51,7 +50,7 @@ data class SakTypeJackson(
 ) {
     @JacksonXmlProperty(localName = "Melding")
     @JacksonXmlElementWrapper(useWrapping = false)
-    var meldinger: List<MeldingType> = mutableListOf()
+    var meldinger: List<MeldingTypeJackson> = mutableListOf()
         set(value) {
             field = meldinger + value
         }

--- a/src/test/groovy/no/ssb/barn/converter/BarnvernConverterJacksonSpec.groovy
+++ b/src/test/groovy/no/ssb/barn/converter/BarnvernConverterJacksonSpec.groovy
@@ -1,6 +1,8 @@
 package no.ssb.barn.converter
 
 import no.ssb.barn.testutil.TestDataProvider
+import no.ssb.barn.validation.ValidationContext
+import no.ssb.barn.validation.rule.XsdRule
 import spock.lang.Specification
 
 import java.time.ZonedDateTime
@@ -34,5 +36,22 @@ class BarnvernConverterJacksonSpec extends Specification {
         verifyAll(barnevernInstance.sak) {
             it.meldinger.size() == 1
         }
+    }
+
+    def "when marshallXml using Jackson, XML is valid"() {
+        given: "a deserialized BarnevernTypeJackson instance"
+        def barnevernInstance = BarnvernConverterJackson.unmarshallXml(
+                TestDataProvider.getResourceAsString("test01_file09_total.xml"))
+        and: "an XSD validator"
+        def xsdValidator = new XsdRule("Barnevern.xsd")
+
+        when: "serializing instance to XML"
+        def xml = BarnvernConverterJackson.marshallInstance(barnevernInstance)
+        and: "validating XML against XSD"
+        def validationResult = xsdValidator.validate(
+                new ValidationContext("~messageId~", xml))
+
+        then: "validation result should be null"
+        null == validationResult
     }
 }

--- a/src/test/groovy/no/ssb/barn/converter/BarnvernConverterJacksonSpec.groovy
+++ b/src/test/groovy/no/ssb/barn/converter/BarnvernConverterJacksonSpec.groovy
@@ -1,0 +1,38 @@
+package no.ssb.barn.converter
+
+import no.ssb.barn.testutil.TestDataProvider
+import spock.lang.Specification
+
+import java.time.ZonedDateTime
+
+@SuppressWarnings('SpellCheckingInspection')
+class BarnvernConverterJacksonSpec extends Specification {
+
+    def "unmarshallXml using Jackson, expect valid instance"() {
+        when: "unmarshalling XML"
+        def barnevernInstance = BarnvernConverterJackson.unmarshallXml(
+                TestDataProvider.getResourceAsString("test01_file09_total.xml"))
+
+        then: "barnevernInstance should not be null"
+        null != barnevernInstance
+
+        and: "all top level fields should be set"
+        verifyAll(barnevernInstance) {
+            it.id == UUID.fromString("1b1907ef-2080-42c8-b704-3b33bf0b0982")
+            it.forrigeId == "b8c7cd5a-376b-405c-9f0f-2cf1002752d9"
+            it.datoUttrekk.toEpochSecond() == ZonedDateTime.parse("2021-01-01T13:22:00+01:00").toEpochSecond()
+        }
+
+        and: "all fagsystem fields should be set"
+        verifyAll(barnevernInstance.fagsystem) {
+            it.versjon == "1.0"
+            it.leverandor == "SSB"
+            it.navn == "OJJ's Manuell Touch"
+        }
+
+        and: "there should be one instance om MeldingType"
+        verifyAll(barnevernInstance.sak) {
+            it.meldinger.size() == 1
+        }
+    }
+}


### PR DESCRIPTION
Denne PRen handler om å teste ut Jackson for å unngå at members i Kotlin dataklasser må deklareres som nullable.

Det er lagt til JaxbAnnotationModule slik at Jackson vil forstå eksisterende annoteringer. Det som krever spesialhåndtering, er kolleksjoner av elementer, som f.eks. elementet `Melding`. Dette er vist bl.a. nederst i klassene `SakTypeJackson` og `MeldingTypeJackson`.